### PR TITLE
Possible fix to null crates

### DIFF
--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -498,7 +498,12 @@
 //(this is exclusively used for the rare variant of the stray cargo event!)
 /datum/supply_pack/misc/syndicate/fill(obj/structure/closet/crate/C)
 	var/list/uplink_items = get_uplink_items(SSticker.mode)
+	/* LUMOS EDIT REMOVAL
 	while(crate_value)
+	*/
+	//LUMOS EDIT BEGIN
+	while(crate_value && length(uplink_items))
+	//LUMOS EDIT END
 		var/category = pick(uplink_items)
 		var/item = pick(uplink_items[category])
 		var/datum/uplink_item/I = uplink_items[category][item]


### PR DESCRIPTION
Null crates can sometimes runtime and this apparently bricks every single null crate spawned after that. This PR half solves the issue by not causing the runtime with a check for length on the list.